### PR TITLE
Added promise await in DIC

### DIFF
--- a/.formatter.yml
+++ b/.formatter.yml
@@ -7,7 +7,7 @@ use-sort:
 strict: true
 header: |
     /*
-     * This file is part of the Drift Http Kernel
+     * This file is part of the DriftPHP Project
      *
      * For the full copyright and license information, please view the LICENSE
      * file that was distributed with this source code.

--- a/AsyncEventDispatcher.php
+++ b/AsyncEventDispatcher.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/AsyncEventDispatcherInterface.php
+++ b/AsyncEventDispatcherInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/AsyncEventDispatcherMethods.php
+++ b/AsyncEventDispatcherMethods.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/AsyncHttpKernel.php
+++ b/AsyncHttpKernel.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -221,7 +221,7 @@ class AsyncHttpKernel extends HttpKernel
                 return $this
                     ->dispatcher
                     ->asyncDispatch(KernelEvents::VIEW, $event)
-                    ->then(function(ViewEvent $event) use ($controller, $response) {
+                    ->then(function (ViewEvent $event) use ($controller, $response) {
                         if ($event->hasResponse()) {
                             return $event->getResponse();
                         } else {

--- a/AsyncKernel.php
+++ b/AsyncKernel.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Drift\HttpKernel;
 
+use Drift\HttpKernel\DependencyInjection\CompilerPass\AsyncServicesCompilerPass;
 use Drift\HttpKernel\DependencyInjection\CompilerPass\EventDispatcherCompilerPass;
 use Drift\HttpKernel\DependencyInjection\CompilerPass\EventLoopCompilerPass;
 use Drift\HttpKernel\DependencyInjection\CompilerPass\FilesystemCompilerPass;
@@ -69,6 +70,7 @@ abstract class AsyncKernel extends Kernel implements CompilerPassInterface
         $container->addCompilerPass(new EventLoopCompilerPass());
         $container->addCompilerPass(new EventDispatcherCompilerPass($this->isDebug()));
         $container->addCompilerPass(new FilesystemCompilerPass());
+        $container->addCompilerPass(new AsyncServicesCompilerPass());
     }
 
     /**

--- a/AsyncKernel.php
+++ b/AsyncKernel.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/AsyncKernelEvents.php
+++ b/AsyncKernelEvents.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/AsyncServiceAwaiter.php
+++ b/AsyncServiceAwaiter.php
@@ -1,30 +1,41 @@
 <?php
 
+/*
+ * This file is part of the DriftPHP Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
 
 namespace Drift\HttpKernel;
 
+use function Clue\React\Block\await;
 use React\EventLoop\LoopInterface;
 use React\Promise\PromiseInterface;
-use function Clue\React\Block\await;
 
 /**
- * Class AsyncContainer
+ * Class AsyncContainer.
  */
 class AsyncServiceAwaiter
 {
     /**
-     * Await
+     * Await.
      *
      * @param LoopInterface $loop
-     * @param object $service
+     * @param object        $service
      *
      * @return object
      */
     public static function await(
         LoopInterface $loop,
         $service
-    )
-    {
+    ) {
         return ($service instanceof PromiseInterface)
             ? await($service, $loop)
             : $service;

--- a/AsyncServiceAwaiter.php
+++ b/AsyncServiceAwaiter.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace Drift\HttpKernel;
+
+use React\EventLoop\LoopInterface;
+use React\Promise\PromiseInterface;
+use function Clue\React\Block\await;
+
+/**
+ * Class AsyncContainer
+ */
+class AsyncServiceAwaiter
+{
+    /**
+     * Await
+     *
+     * @param LoopInterface $loop
+     * @param object $service
+     *
+     * @return object
+     */
+    public static function await(
+        LoopInterface $loop,
+        $service
+    )
+    {
+        return ($service instanceof PromiseInterface)
+            ? await($service, $loop)
+            : $service;
+    }
+}

--- a/DependencyInjection/CompilerPass/AsyncServicesCompilerPass.php
+++ b/DependencyInjection/CompilerPass/AsyncServicesCompilerPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Class AsyncServicesCompilerPass
+ * Class AsyncServicesCompilerPass.
  */
 class AsyncServicesCompilerPass implements CompilerPassInterface
 {
@@ -38,17 +38,17 @@ class AsyncServicesCompilerPass implements CompilerPassInterface
 
         foreach ($servicesId as $serviceId => $_) {
             $promiseDefinition = $container->getDefinition($serviceId);
-            $container->setDefinition($serviceId . '.promise', $promiseDefinition);
+            $container->setDefinition($serviceId.'.promise', $promiseDefinition);
 
             $decorator = new Definition($promiseDefinition->getClass(), [
                 new Reference(LoopInterface::class),
-                new Reference($serviceId . '.promise')
+                new Reference($serviceId.'.promise'),
             ]);
 
             $decorator->setPublic($promiseDefinition->isPublic());
             $decorator->setFactory([
                 AsyncServiceAwaiter::class,
-                'await'
+                'await',
             ]);
 
             $container->setDefinition($serviceId, $decorator);

--- a/DependencyInjection/CompilerPass/AsyncServicesCompilerPass.php
+++ b/DependencyInjection/CompilerPass/AsyncServicesCompilerPass.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Drift Http Kernel
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Drift\HttpKernel\DependencyInjection\CompilerPass;
+
+use Drift\HttpKernel\AsyncServiceAwaiter;
+use React\EventLoop\LoopInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class AsyncServicesCompilerPass
+ */
+class AsyncServicesCompilerPass implements CompilerPassInterface
+{
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $servicesId = $container->findTaggedServiceIds('await');
+
+        foreach ($servicesId as $serviceId => $_) {
+            $promiseDefinition = $container->getDefinition($serviceId);
+            $container->setDefinition($serviceId . '.promise', $promiseDefinition);
+
+            $decorator = new Definition($promiseDefinition->getClass(), [
+                new Reference(LoopInterface::class),
+                new Reference($serviceId . '.promise')
+            ]);
+
+            $decorator->setPublic($promiseDefinition->isPublic());
+            $decorator->setFactory([
+                AsyncServiceAwaiter::class,
+                'await'
+            ]);
+
+            $container->setDefinition($serviceId, $decorator);
+        }
+    }
+}

--- a/DependencyInjection/CompilerPass/EventDispatcherCompilerPass.php
+++ b/DependencyInjection/CompilerPass/EventDispatcherCompilerPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Class EventDispatcherCompilerPass
+ * Class EventDispatcherCompilerPass.
  */
 class EventDispatcherCompilerPass implements CompilerPassInterface
 {

--- a/DependencyInjection/CompilerPass/EventLoopCompilerPass.php
+++ b/DependencyInjection/CompilerPass/EventLoopCompilerPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
- * Class EventLoopCompilerPass
+ * Class EventLoopCompilerPass.
  */
 class EventLoopCompilerPass implements CompilerPassInterface
 {

--- a/DependencyInjection/CompilerPass/FilesystemCompilerPass.php
+++ b/DependencyInjection/CompilerPass/FilesystemCompilerPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Class FilesystemCompilerPass
+ * Class FilesystemCompilerPass.
  */
 class FilesystemCompilerPass implements CompilerPassInterface
 {

--- a/Event/PreloadEvent.php
+++ b/Event/PreloadEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Exception/AsyncEventDispatcherNeededException.php
+++ b/Exception/AsyncEventDispatcherNeededException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Exception/AsyncHttpKernelNeededException.php
+++ b/Exception/AsyncHttpKernelNeededException.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Symfony Async Kernel
+# DriftPHP Http Kernel
 
 [![CircleCI](https://circleci.com/gh/driftphp/http-kernel.svg?style=svg)](https://circleci.com/gh/driftphp/http-kernel)
 

--- a/Tests/AsyncKernelFunctionalTest.php
+++ b/Tests/AsyncKernelFunctionalTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Base/AsyncDebugFunctionalTest.php
+++ b/Tests/Base/AsyncDebugFunctionalTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Base/AsyncFunctionalTest.php
+++ b/Tests/Base/AsyncFunctionalTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Base/AutowiringDebugTest.php
+++ b/Tests/Base/AutowiringDebugTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Base/AutowiringTest.php
+++ b/Tests/Base/AutowiringTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Base/ContainerFulfilledPromiseTest.php
+++ b/Tests/Base/ContainerFulfilledPromiseTest.php
@@ -1,0 +1,44 @@
+<?php
+
+
+namespace Drift\HttpKernel\Tests\Base;
+
+use Drift\HttpKernel\Tests\AsyncKernelFunctionalTest;
+use Drift\HttpKernel\Tests\Services\AClass;
+use Drift\HttpKernel\Tests\Services\AFactory;
+
+/**
+ * Class ContainerPromiseTest
+ */
+class ContainerFulfilledPromiseTest extends AsyncKernelFunctionalTest
+{
+    /**
+     * Decorate configuration.
+     *
+     * @param array $configuration
+     *
+     * @return array
+     */
+    protected static function decorateConfiguration(array $configuration): array
+    {
+        $configuration['services'][AClass::class] = [
+            'factory' => [
+                AFactory::class,
+                'createAFulfilledClass'
+            ],
+            'tags' => [
+                ['name' => 'await']
+            ]
+        ];
+
+        return $configuration;
+    }
+
+    /**
+     * Test a class instance
+     */
+    public function testAClass()
+    {
+        $this->assertInstanceOf(AClass::class, $this->get(AClass::class));
+    }
+}

--- a/Tests/Base/ContainerFulfilledPromiseTest.php
+++ b/Tests/Base/ContainerFulfilledPromiseTest.php
@@ -1,5 +1,17 @@
 <?php
 
+/*
+ * This file is part of the DriftPHP Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
 
 namespace Drift\HttpKernel\Tests\Base;
 
@@ -8,7 +20,7 @@ use Drift\HttpKernel\Tests\Services\AClass;
 use Drift\HttpKernel\Tests\Services\AFactory;
 
 /**
- * Class ContainerPromiseTest
+ * Class ContainerPromiseTest.
  */
 class ContainerFulfilledPromiseTest extends AsyncKernelFunctionalTest
 {
@@ -24,18 +36,18 @@ class ContainerFulfilledPromiseTest extends AsyncKernelFunctionalTest
         $configuration['services'][AClass::class] = [
             'factory' => [
                 AFactory::class,
-                'createAFulfilledClass'
+                'createAFulfilledClass',
             ],
             'tags' => [
-                ['name' => 'await']
-            ]
+                ['name' => 'await'],
+            ],
         ];
 
         return $configuration;
     }
 
     /**
-     * Test a class instance
+     * Test a class instance.
      */
     public function testAClass()
     {

--- a/Tests/Base/ContainerRejectedPromiseTest.php
+++ b/Tests/Base/ContainerRejectedPromiseTest.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace Drift\HttpKernel\Tests\Base;
+
+use Drift\HttpKernel\Tests\AsyncKernelFunctionalTest;
+use Drift\HttpKernel\Tests\Services\AClass;
+use Drift\HttpKernel\Tests\Services\AFactory;
+
+/**
+ * Class ContainerRejectedPromiseTest
+ */
+class ContainerRejectedPromiseTest extends AsyncKernelFunctionalTest
+{
+    /**
+     * Decorate configuration.
+     *
+     * @param array $configuration
+     *
+     * @return array
+     */
+    protected static function decorateConfiguration(array $configuration): array
+    {
+        $configuration['services'][AClass::class] = [
+            'factory' => [
+                AFactory::class,
+                'createARejectedClass'
+            ],
+            'tags' => [
+                ['name' => 'await']
+            ]
+        ];
+
+        return $configuration;
+    }
+
+    /**
+     * Test a class instance
+     */
+    public function testAClass()
+    {
+        $this->expectException(\Exception::class);
+        $this->get(AClass::class);
+    }
+}

--- a/Tests/Base/ContainerRejectedPromiseTest.php
+++ b/Tests/Base/ContainerRejectedPromiseTest.php
@@ -1,5 +1,17 @@
 <?php
 
+/*
+ * This file is part of the DriftPHP Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
 
 namespace Drift\HttpKernel\Tests\Base;
 
@@ -8,7 +20,7 @@ use Drift\HttpKernel\Tests\Services\AClass;
 use Drift\HttpKernel\Tests\Services\AFactory;
 
 /**
- * Class ContainerRejectedPromiseTest
+ * Class ContainerRejectedPromiseTest.
  */
 class ContainerRejectedPromiseTest extends AsyncKernelFunctionalTest
 {
@@ -24,18 +36,18 @@ class ContainerRejectedPromiseTest extends AsyncKernelFunctionalTest
         $configuration['services'][AClass::class] = [
             'factory' => [
                 AFactory::class,
-                'createARejectedClass'
+                'createARejectedClass',
             ],
             'tags' => [
-                ['name' => 'await']
-            ]
+                ['name' => 'await'],
+            ],
         ];
 
         return $configuration;
     }
 
     /**
-     * Test a class instance
+     * Test a class instance.
      */
     public function testAClass()
     {

--- a/Tests/Base/GetResponsePromiseFunctionalTest.php
+++ b/Tests/Base/GetResponsePromiseFunctionalTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Base/GetResponsesPromiseFunctionalMidPromiseTest.php
+++ b/Tests/Base/GetResponsesPromiseFunctionalMidPromiseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Base/GetResponsesPromiseFunctionalNoPromiseTest.php
+++ b/Tests/Base/GetResponsesPromiseFunctionalNoPromiseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Base/GetResponsesPromiseFunctionalTest.php
+++ b/Tests/Base/GetResponsesPromiseFunctionalTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Base/KernelServicesTest.php
+++ b/Tests/Base/KernelServicesTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Base/PreloadTest.php
+++ b/Tests/Base/PreloadTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Base/SyncFunctionalTest.php
+++ b/Tests/Base/SyncFunctionalTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Base/TwigTest.php
+++ b/Tests/Base/TwigTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Controller.php
+++ b/Tests/Controller.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Listener.php
+++ b/Tests/Listener.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -136,11 +136,9 @@ class Listener
     public function handleView(ViewEvent $event)
     {
         return (new FulfilledPromise($event))
-            ->then(function(ViewEvent $event) {
-
+            ->then(function (ViewEvent $event) {
                 $event->setResponse(new JsonResponse($event->getControllerResult()));
             });
-
     }
 
     /**

--- a/Tests/NoStopwatch/AsyncDebugFunctionalTest.php
+++ b/Tests/NoStopwatch/AsyncDebugFunctionalTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/NoStopwatch/AutowiringDebugTest.php
+++ b/Tests/NoStopwatch/AutowiringDebugTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Services/AClass.php
+++ b/Tests/Services/AClass.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Drift\HttpKernel\Tests\Services;
+
+
+final class AClass
+{
+
+}

--- a/Tests/Services/AClass.php
+++ b/Tests/Services/AClass.php
@@ -1,10 +1,20 @@
 <?php
 
+/*
+ * This file is part of the DriftPHP Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
 
 namespace Drift\HttpKernel\Tests\Services;
 
-
 final class AClass
 {
-
 }

--- a/Tests/Services/AFactory.php
+++ b/Tests/Services/AFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -40,24 +40,24 @@ final class AFactory
     }
 
     /**
-     * Create a class
+     * Create a class.
      */
-    public static function createAFulfilledClass() : PromiseInterface
+    public static function createAFulfilledClass(): PromiseInterface
     {
         return (new FulfilledPromise())
-            ->then(function() {
+            ->then(function () {
                 return new AClass();
             });
     }
 
     /**
-     * Create a class
+     * Create a class.
      */
-    public static function createARejectedClass() : PromiseInterface
+    public static function createARejectedClass(): PromiseInterface
     {
         return (new FulfilledPromise())
-            ->then(function() {
-                throw new \Exception;
+            ->then(function () {
+                throw new \Exception();
             });
     }
 }

--- a/Tests/Services/AFactory.php
+++ b/Tests/Services/AFactory.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Drift Http Kernel
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Drift\HttpKernel\Tests\Services;
+
+use React\EventLoop\LoopInterface;
+use React\Promise\FulfilledPromise;
+use React\Promise\PromiseInterface;
+
+/**
+ * Class AService.
+ */
+final class AFactory
+{
+    /**
+     * @var LoopInterface
+     */
+    private $loop;
+
+    /**
+     * AFactory constructor.
+     *
+     * @param LoopInterface $loop
+     */
+    public function __construct(LoopInterface $loop)
+    {
+        $this->loop = $loop;
+    }
+
+    /**
+     * Create a class
+     */
+    public static function createAFulfilledClass() : PromiseInterface
+    {
+        return (new FulfilledPromise())
+            ->then(function() {
+                return new AClass();
+            });
+    }
+
+    /**
+     * Create a class
+     */
+    public static function createARejectedClass() : PromiseInterface
+    {
+        return (new FulfilledPromise())
+            ->then(function() {
+                throw new \Exception;
+            });
+    }
+}

--- a/Tests/Services/AService.php
+++ b/Tests/Services/AService.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/TraceableAsyncEventDispatcher.php
+++ b/TraceableAsyncEventDispatcher.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Drift Http Kernel
+ * This file is part of the DriftPHP Project
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         "symfony/dependency-injection": "^5.0",
         "symfony/event-dispatcher-contracts": "^2.0",
         "react/promise": "^2.7",
-        "react/filesystem": "^0.1"
+        "react/filesystem": "^0.1",
+        "clue/block-react": "^1.3"
     },
     "require-dev": {
         "mmoreram/base-bundle": "^2.1.0",
         "symfony/yaml": "^5.0",
-        "symfony/console": "^5.0",
-        "clue/block-react": "^1.3"
+        "symfony/console": "^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Services should be autoloaded solved before the first request is served.
This means that we could take in consideration to await all Promises to
be solved before start handling requests. This is why we can select a
DIC service as `await` by using a simple tag, and the container will
await the promise to be fulfilled or rejected.

```php
My\Future\Service:
    tags:
        - {"name": "async"}
```