### PR TITLE
Added periodic_timer feature

### DIFF
--- a/DependencyInjection/CompilerPass/PeriodicTimersCompilerPass.php
+++ b/DependencyInjection/CompilerPass/PeriodicTimersCompilerPass.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace Drift\HttpKernel\DependencyInjection\CompilerPass;
+
+use Drift\HttpKernel\PeriodicTimer\PeriodicTimer;
+use React\EventLoop\LoopInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class PeriodicTimersCompilerPass
+ */
+class PeriodicTimersCompilerPass implements CompilerPassInterface
+{
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $servicesId = $container->findTaggedServiceIds('periodic_timer');
+
+        $periodicTimer = new Definition(PeriodicTimer::class, [
+            new Reference(LoopInterface::class)
+        ]);
+
+        foreach ($servicesId as $serviceId => $serviceRows) {
+            foreach ($serviceRows as $serviceRow) {
+                $frequency = $serviceRow['interval'];
+
+                if ($frequency <= 0) {
+                    throw new \Exception('You should define an interval value (in seconds) when defining a periodic timer');
+                }
+
+                $method = $serviceRow['method'];
+                $periodicTimer->addMethodCall('addServiceCall', [
+                    $frequency,
+                    new Reference($serviceId),
+                    $method
+                ]);
+            }
+        }
+
+        $periodicTimer->addTag('kernel.event_listener', [
+            'event' => 'kernel.preload'
+        ]);
+
+        $container->setDefinition(PeriodicTimer::class, $periodicTimer);
+    }
+}

--- a/PeriodicTimer/PeriodicTimer.php
+++ b/PeriodicTimer/PeriodicTimer.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the DriftPHP Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Drift\HttpKernel\PeriodicTimer;
+
+use React\EventLoop\LoopInterface;
+
+/**
+ * Class PeriodicTimer
+ */
+final class PeriodicTimer
+{
+    /**
+     * @var LoopInterface
+     */
+    private $loop;
+
+    /**
+     * @param LoopInterface $loop
+     */
+    public function __construct(LoopInterface $loop)
+    {
+        $this->loop = $loop;
+    }
+
+    /**
+     * @param float  $frequencyInSeconds
+     * @param Object $service
+     * @param string $method
+     */
+    public function addServiceCall(
+        float $frequencyInSeconds,
+        Object $service,
+        string $method
+    )
+    {
+        $this
+            ->loop
+            ->addPeriodicTimer($frequencyInSeconds, function() use ($service, $method) {
+                $service->$method();
+            });
+    }
+}

--- a/Tests/Base/GetPSR7ResponsePromiseFunctionalTest.php
+++ b/Tests/Base/GetPSR7ResponsePromiseFunctionalTest.php
@@ -28,8 +28,6 @@ class GetPSR7ResponsePromiseFunctionalTest extends AsyncKernelFunctionalTest
 {
     /**
      * Everything should work as before in the world of sync requests.
-     *
-     * @group lele
      */
     public function testSyncKernel()
     {

--- a/Tests/Base/GetResponsePromiseFunctionalTest.php
+++ b/Tests/Base/GetResponsePromiseFunctionalTest.php
@@ -65,8 +65,6 @@ class GetResponsePromiseFunctionalTest extends AsyncKernelFunctionalTest
 
     /**
      * Everything should work as before in the world of sync requests.
-     *
-     * @group lele
      */
     public function testSyncKernel()
     {

--- a/Tests/Base/GetResponsesPromiseFunctionalNoPromiseTest.php
+++ b/Tests/Base/GetResponsesPromiseFunctionalNoPromiseTest.php
@@ -68,8 +68,6 @@ class GetResponsesPromiseFunctionalNoPromiseTest extends AsyncKernelFunctionalTe
 
     /**
      * Everything should work as before in the world of sync requests.
-     *
-     * @group lele
      */
     public function testSyncKernel()
     {

--- a/Tests/Base/PeriodicTimerTest.php
+++ b/Tests/Base/PeriodicTimerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+
+namespace Drift\HttpKernel\Tests\Base;
+
+
+use Drift\HttpKernel\Tests\AsyncKernelFunctionalTest;
+use Drift\HttpKernel\Tests\Services\ACounter;
+use function Clue\React\Block\await;
+use function Drift\React\usleep;
+
+/**
+ * Class PeriodicTimerTest
+ */
+class PeriodicTimerTest extends AsyncKernelFunctionalTest
+{
+    /**
+     * Decorate configuration.
+     *
+     * @param array $configuration
+     *
+     * @return array
+     */
+    protected static function decorateConfiguration(array $configuration): array
+    {
+        $configuration = parent::decorateConfiguration($configuration);
+        $configuration['services'][ACounter::class] = [
+            'class' => ACounter::class,
+            'tags' => [
+                [
+                    'name' => 'periodic_timer',
+                    'interval' => '0.1',
+                    'method' => 'increaseI',
+                ],
+                [
+                    'name' => 'periodic_timer',
+                    'interval' => '0.1',
+                    'method' => 'increaseX',
+                ],
+                [
+                    'name' => 'periodic_timer',
+                    'interval' => '0.3',
+                    'method' => 'increase2X',
+                ],
+                [
+                    'name' => 'periodic_timer',
+                    'interval' => '0.7',
+                    'method' => 'increaseX',
+                ]
+            ],
+        ];
+
+        return $configuration;
+    }
+
+    /**
+     * Test periodic timer
+     */
+    public function testPeriodicTimer()
+    {
+        self::$kernel->preload();
+
+        $loop = static::get('reactphp.event_loop');
+        await(usleep(1050000, $loop), $loop);
+
+        $this->assertEquals(10, self::get(ACounter::class)->getI());
+        $this->assertEquals(14, self::get(ACounter::class)->getX());
+
+        await(usleep(350000, $loop), $loop);
+
+        $this->assertEquals(13, self::get(ACounter::class)->getI());
+        $this->assertEquals(19, self::get(ACounter::class)->getX());
+    }
+}

--- a/Tests/Services/ACounter.php
+++ b/Tests/Services/ACounter.php
@@ -1,0 +1,60 @@
+<?php
+
+
+namespace Drift\HttpKernel\Tests\Services;
+
+/**
+ * Class ACounter
+ */
+class ACounter
+{
+    /**
+     * @var int
+     */
+    private $i = 0;
+
+    /**
+     * @var int
+     */
+    private $x = 0;
+
+    /**
+     * Increase
+     */
+    public function increaseI()
+    {
+        $this->i++;
+    }
+
+    /**
+     * Increase
+     */
+    public function increaseX()
+    {
+        $this->x++;
+    }
+
+    /**
+     * Increase
+     */
+    public function increase2X()
+    {
+        $this->x++;
+    }
+
+    /**
+     * @return int
+     */
+    public function getI()
+    {
+        return $this->i;
+    }
+
+    /**
+     * @return int
+     */
+    public function getX()
+    {
+        return $this->x;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require-dev": {
         "phpunit/phpunit": "7.5.17",
         "mmoreram/base-bundle": "^2.1.0",
+        "drift/react-functions": "^0.1",
         "symfony/yaml": "^5.0",
         "symfony/console": "^5.0"
     },


### PR DESCRIPTION
- It basically runs a periodic timer in the loop in order to execute,
each `N` seconds, a service method.
- Fixed some style as well

```yml
SomeService:
    tags:
        - {"name": "periodic_timer", "interval": 1.0, "method":
"doSomethingEachSecond"}
```